### PR TITLE
fixing casing of one of the menu links

### DIFF
--- a/src/data/nav.json
+++ b/src/data/nav.json
@@ -74,7 +74,7 @@
   "About": [
     {
       "path": "/about/how-to-contribute",
-      "title": "How to contribute"
+      "title": "How to Contribute"
     },
     {
       "path": "/about/privacy-attribution",


### PR DESCRIPTION
every other major word is capitalized in the menu. Contribute is not. Looked weird