### PR TITLE
remove extension from search result links

### DIFF
--- a/public/js/Search.0.1.0.js
+++ b/public/js/Search.0.1.0.js
@@ -124,8 +124,10 @@ class Search {
       this.#searchResults.innerHTML = '';
       for (const result of results) {
         const data = await result.data();
+        // Remove the extension from the URL
+        const urlNoExt = data.url.replace(/\.[^/.]+$/, "");
         this.#searchResults.innerHTML += `<li class="group" data-widget="search-result">
-          <a href="${data.url}" class="bg-slate-100 rounded-md flex group items-center px-4 py-2 dark:bg-slate-700 group-[.active]:bg-indigo-600 group-[.active]:text-white">
+          <a href="${urlNoExt}" class="bg-slate-100 rounded-md flex group items-center px-4 py-2 dark:bg-slate-700 group-[.active]:bg-indigo-600 group-[.active]:text-white">
             <i class="bg-white border border-slate-900/10 fa-regular fa-hashtag mr-4 px-1 py-0.5 rounded-md shadow-sm text-slate-400 text-sm dark:bg-slate-600 group-[.active]:bg-indigo-600 group-[.active]:border-indigo-300 group-[.active]:text-white"></i>
             <div class="flex flex-col">
               <span class="bg-slate-200 border border-slate-900/10 font-semibold mb-2 px-2 py-0.5 rounded-full text-slate-700 text-xs w-fit dark:bg-slate-600 dark:text-slate-400 group-[.active]:bg-indigo-500 group-[.active]:border-indigo-300 group-[.active]:text-white">


### PR DESCRIPTION
The JavaScript building links in Pagefind results included the `.html` extension with the URLs.

This change removes the extension from search result links.